### PR TITLE
add token verify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
 
 	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 

--- a/src/main/kotlin/com/orca/gateway/GatewayApplication.kt
+++ b/src/main/kotlin/com/orca/gateway/GatewayApplication.kt
@@ -8,6 +8,6 @@ import org.springframework.boot.runApplication
 @SpringBootApplication
 class GatewayApplication
 
-suspend fun main(args: Array<String>) {
+fun main(args: Array<String>) {
 	runApplication<GatewayApplication>(*args)
 }

--- a/src/main/kotlin/com/orca/gateway/auth/filter/AuthFilter.kt
+++ b/src/main/kotlin/com/orca/gateway/auth/filter/AuthFilter.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.orca.gateway.exception.AuthError
 import com.orca.gateway.exception.ErrorResponse
 import com.orca.gateway.external.AuthService
-import kotlinx.coroutines.reactor.mono
 import org.springframework.cloud.gateway.filter.GatewayFilter
 import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
@@ -20,20 +22,33 @@ class AuthFilter(
     override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
         val authToken = exchange.request.headers.getFirst("Authorization")
 
-        return if (authToken == null || !authToken.startsWith("Bearer ")) {
-            val response = ErrorResponse(AuthError.TOKEN_NOT_FOUND)
-            exchange.response.run {
-                statusCode = response.status
-                writeWith(Mono.just(bufferFactory().wrap(objectMapper.writeValueAsBytes(response))))
-            }
-            Mono.empty()
+        return if (isValidToken(authToken)) {
+            val token = authToken!!.substring(7)
+            authService.verifyToken(token)
+                .flatMap {
+                    exchange.response.writeResponse(
+                        exchange = exchange,
+                        statusCode = it.statusCode,
+                        response = it.body!!
+                    )
+                }
+                .switchIfEmpty(chain.filter(exchange))
         } else {
-            val token = authToken.substring(7)
-            mono {
-                authService.verifyToken(token)
-            }
-                .flatMap { chain.filter(exchange) }
+            exchange.response.writeResponse(
+                exchange = exchange,
+                statusCode = HttpStatus.UNAUTHORIZED,
+                response = ErrorResponse(AuthError.TOKEN_NOT_FOUND)
+            )
         }
+    }
+
+    fun ServerHttpResponse.writeResponse(exchange: ServerWebExchange, statusCode: HttpStatusCode, response: Any): Mono<Void> {
+        this.statusCode = statusCode
+        return writeWith(Mono.just(bufferFactory().wrap(objectMapper.writeValueAsBytes(response))))
+    }
+
+    fun isValidToken(token: String?): Boolean {
+        return token != null && token.startsWith("Bearer ")
     }
 }
 

--- a/src/main/kotlin/com/orca/gateway/exception/ErrorResponse.kt
+++ b/src/main/kotlin/com/orca/gateway/exception/ErrorResponse.kt
@@ -1,21 +1,17 @@
 package com.orca.gateway.exception
 
-import org.springframework.http.HttpStatus
+import com.orca.gateway.util.getCurrentTimestamp
 
 class ErrorResponse(
-    val status: HttpStatus,
-    val message: String
+    val serviceName: String,
+    val code: String,
+    val message: String,
+    val timestamp: String
 ) {
-    constructor(e: AuthError): this(
-        status = e.httpStatus!!,
-        message = e.message
+    constructor(e: AuthError) : this(
+        serviceName = "gateway",
+        code = e.name,
+        message = e.message,
+        timestamp = getCurrentTimestamp(),
     )
-    companion object {
-        fun default(): ErrorResponse {
-            return ErrorResponse(
-                status = HttpStatus.INTERNAL_SERVER_ERROR,
-                message = "UNDEFINED EXCEPTION",
-            )
-        }
-    }
 }

--- a/src/main/kotlin/com/orca/gateway/exception/GatewayError.kt
+++ b/src/main/kotlin/com/orca/gateway/exception/GatewayError.kt
@@ -1,0 +1,7 @@
+package com.orca.gateway.exception
+
+import org.springframework.http.HttpStatus
+
+enum class GatewayError(val status: HttpStatus? = HttpStatus.INTERNAL_SERVER_ERROR, val message: String) {
+    UNDEFINED_EXCEPTION(message = "Sorry, undefined exception"),
+}

--- a/src/main/kotlin/com/orca/gateway/external/ServerConfig.kt
+++ b/src/main/kotlin/com/orca/gateway/external/ServerConfig.kt
@@ -1,0 +1,13 @@
+package com.orca.gateway.external
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external")
+data class ServerConfig(
+    val map: Map<String, ServerInfo> = emptyMap()
+) {
+    data class ServerInfo(
+        val host: String,
+        val port: Int
+    )
+}

--- a/src/main/kotlin/com/orca/gateway/external/WebClientFactory.kt
+++ b/src/main/kotlin/com/orca/gateway/external/WebClientFactory.kt
@@ -1,18 +1,25 @@
 package com.orca.gateway.external
 
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
-class ExternalConfig {
-    @Bean
-    fun webClient(): WebClient {
-        return WebClient.builder()
+class WebClientFactory(
+    private val serverConfig: ServerConfig
+) {
+    private val clients = serverConfig.map.mapValues { (name, info) ->
+        WebClient.builder()
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .baseUrl("https://${info.host}:${info.port}/$name")
             .build()
     }
+
+    fun getClient(name: String): WebClient {
+        return checkNotNull(clients[name]) { "Undefined service name: $name" }
+    }
 }
+
+

--- a/src/main/kotlin/com/orca/gateway/util/UtilMethods.kt
+++ b/src/main/kotlin/com/orca/gateway/util/UtilMethods.kt
@@ -1,0 +1,9 @@
+package com.orca.gateway.util
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+fun getCurrentTimestamp(): String {
+    return LocalDateTime.now()
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+}


### PR DESCRIPTION
- auth 서비스를 통해 token을 검증
 - 검증 성공 -> 다음 필터
 - 검증 실패 -> ErrorResponse
- 코루틴 제거
 - Gateway는 각 마이크로서비스로 요청/응답을 전송하는 역할만 담당하기 때문에 코루틴을 활용할만한 요소가 부족함
 - Mono와의 혼용으로 인해 코드가 불필요하게 복잡해짐. WebClient를 주로 활용하기 때문에 Mono / Flux 를 배제할수는 없음